### PR TITLE
feat(ci): add PR Smoke job and @smoke tags for fast, deterministic PR gating

### DIFF
--- a/.github/workflows/pr-smoke.yml
+++ b/.github/workflows/pr-smoke.yml
@@ -1,0 +1,57 @@
+name: PR Smoke
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'frontend/**'
+      - 'e2e/**'
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+
+concurrency:
+  group: pr-smoke-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: PR Smoke (Playwright @smoke)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      CI: 'true'
+      NODE_ENV: 'development'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install root deps
+        run: npm ci --prefer-offline --no-audit --no-fund
+
+      - name: Install e2e deps
+        run: npm ci --prefer-offline --no-audit --no-fund
+        working-directory: ./e2e
+
+      - name: Install Playwright browsers
+        uses: microsoft/playwright-github-action@v1
+
+      - name: Run PR smoke
+        run: npm run e2e:smoke
+
+      - name: Upload HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-smoke-report
+          path: e2e/test-results/html-report
+          retention-days: 7

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -35,3 +35,4 @@ Added: /legal hub, /legal/tos, /legal/privacy, /legal/risk-disclosures, /legal/s
 - Root scripts: `e2e:staging` (uses `STAGING_WEB_BASE_URL`), `e2e:report`
 - CI policy: Plan to re-enable “Fast checks” as Required post-merge once green
 - Scope: Frontend/e2e only; no DB schema, auth, payments/custody changes
+- Merge: Squash with message "feat(uat): stabilize SSR region override and align CI summary path"; all required checks green; CodeRabbit approved.

--- a/docs/operator-log.md
+++ b/docs/operator-log.md
@@ -19,3 +19,9 @@
 - **Report Path**: `e2e/test-results/html-report`
 - **Env Used**: `BASE_URL=http://localhost:3000`; region gating defaults from `frontend/env-template`
 - **Notes**: Artifacts ignored via .gitignore; staging script added (`npm run e2e:staging`).
+
+### PR #30 - Merge Result
+
+- **Squash Commit**: feat(uat): stabilize SSR region override and align CI summary path
+- **CI**: All required checks green; CodeRabbit approved
+- **Summary**: SSR-safe override confined to client-only effect; CI lint/build path alignment; no production behavior changed.

--- a/e2e/tests/uat/region-banner.spec.ts
+++ b/e2e/tests/uat/region-banner.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 const BASE = process.env.E2E_BASE_URL || process.env.BASE_URL || process.env.STAGING_WEB_BASE_URL || 'http://localhost:3000';
 
 test.describe('UAT: Region gating banner', () => {
-  test('Banner renders when gating on and region unsupported', async ({ page }) => {
+  test('Banner renders when gating on and region unsupported @smoke', async ({ page }) => {
     test.skip(!process.env.PUBLIC_REGION_GATING || process.env.PUBLIC_REGION_GATING.toLowerCase() !== 'on', 'PUBLIC_REGION_GATING!=on');
     const unsupported = 'AU';
     await page.goto(`${BASE}/?pbce_region=${unsupported}`);

--- a/e2e/tests/uat/routes-and-footer.spec.ts
+++ b/e2e/tests/uat/routes-and-footer.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 const BASE = process.env.E2E_BASE_URL || process.env.BASE_URL || process.env.STAGING_WEB_BASE_URL || 'http://localhost:3000';
 
 test.describe('UAT: Routes and footer links', () => {
-  test('Routes reachability with visible h1', async ({ page, request }) => {
+  test('Routes reachability with visible h1 @smoke', async ({ page, request }) => {
     const routes = [
       '/',
       '/legal',

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test": "echo 'No frontend tests configured yet'",
     "type-check": "tsc --noEmit",
     "e2e:staging": "cd e2e && BASE_URL=$STAGING_WEB_BASE_URL npx playwright test --config playwright.config.ts",
+    "e2e:smoke": "cd e2e && npx playwright test --config playwright.config.ts --project=chromium --workers=1 --grep @smoke",
     "e2e:report": "cd e2e && npx playwright show-report test-results/html-report",
     "prepush": "npx gitleaks detect --verbose --no-git || exit 0"
   },


### PR DESCRIPTION
This adds a minimal PR Smoke workflow and @smoke-tagged Playwright tests.\n\n- New workflow: .github/workflows/pr-smoke.yml (pull_request on frontend/ and e2e/ changes)\n- Tags: @smoke on 2 UAT tests (region banner, routes+footer H1)\n- Scripts: npm run e2e:smoke (chromium, --grep @smoke); npm run e2e:report\n- HTML report: e2e/test-results/html-report (uploaded as artifact)\n- JUnit continues at e2e/test-results/junit.xml per existing config\n\nLocal run:\n\nCounts (local): 1 skipped, 1 passed; ~16s total.\n\nNo changes to existing Fast checks or branch protections.