### PR TITLE
feat(legal): populate four legal hubs with tiles and link all canonical documents

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,10 @@ import Regulatory from './pages/legal/Regulatory';
 import Licenses from './pages/legal/Licenses';
 import LegalList from './pages/legal/LegalList';
 import LegalView from './pages/legal/LegalView';
+import PrivacyHub from './pages/legal/privacy';
+import ComplianceHub from './pages/legal/compliance';
+import TermsRiskHub from './pages/legal/terms-risk';
+import OperationsHub from './pages/legal/operations';
 import Health from './pages/Health';
 import NotFound from './pages/NotFound';
 import AdminTrade from './pages/AdminTrade';
@@ -151,6 +155,10 @@ const App = () => (
             <Route path='/support/security' element={<Security />} />
             <Route path='/support/compliance' element={<Compliance />} />
             <Route path='/legal' element={<LegalList />} />
+            <Route path='/legal/privacy' element={<PrivacyHub />} />
+            <Route path='/legal/compliance' element={<ComplianceHub />} />
+            <Route path='/legal/terms-risk' element={<TermsRiskHub />} />
+            <Route path='/legal/operations' element={<OperationsHub />} />
             <Route path='/legal/:slug' element={<LegalView />} />
             <Route path='/legal/privacy-policy' element={<PrivacyPolicy />} />
             <Route

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -20,16 +20,16 @@ const Footer = () => {
   const supportLinks = [
     { label: 'Help Center', href: '/support/help-center' },
     { label: 'Security', href: '/support/security' },
-    { label: 'Compliance', href: '/support/compliance' },
+    { label: 'Compliance', href: '/legal/compliance' },
     { label: 'Contact', href: '/contact' },
   ];
 
   const legalLinks = [
-    { label: 'Privacy Policy', href: '/legal/privacy-policy' },
-    { label: 'Terms of Service', href: '/legal/terms-of-service' },
-    { label: 'Privacy Choices', href: '/legal/privacy-choices' },
-    { label: 'Accessibility', href: '/legal/accessibility' },
-    { label: 'Disclosures', href: '/legal/risk-disclosures' },
+    { label: 'Privacy & Rights', href: '/legal/privacy' },
+    { label: 'Financial Crime & Sanctions', href: '/legal/compliance' },
+    { label: 'Terms, Consent & Risk', href: '/legal/terms-risk' },
+    { label: 'Operations & Records', href: '/legal/operations' },
+    { label: 'All Legal Documents', href: '/legal' },
   ];
 
   return (

--- a/src/components/trading/HedgingBots.tsx
+++ b/src/components/trading/HedgingBots.tsx
@@ -20,6 +20,7 @@ import {
   TrendingUp,
   BarChart3,
   ExternalLink,
+  Settings,
 } from 'lucide-react';
 
 interface BotConfig {

--- a/src/pages/legal/compliance/index.tsx
+++ b/src/pages/legal/compliance/index.tsx
@@ -1,0 +1,25 @@
+import { Link } from 'react-router-dom';
+
+export default function ComplianceHub() {
+  return (
+    <div className='min-h-screen bg-gradient-to-b from-background to-secondary/20'>
+      <div className='container mx-auto py-12 px-4'>
+        <div className='max-w-4xl mx-auto'>
+          <h1 className='text-4xl font-bold mb-6'>
+            Financial Crime & Sanctions
+          </h1>
+          <p className='text-lg text-muted-foreground mb-8'>
+            Anti-money laundering, sanctions compliance, and financial crime
+            prevention policies.
+          </p>
+          <Link
+            to='/legal'
+            className='text-primary underline hover:no-underline'
+          >
+            View All Legal Documents
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/legal/compliance/index.tsx
+++ b/src/pages/legal/compliance/index.tsx
@@ -1,23 +1,286 @@
 import { Link } from 'react-router-dom';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Globe, Shield, FileText } from 'lucide-react';
 
 export default function ComplianceHub() {
+  const regions = [
+    { id: 'us', name: 'United States' },
+    { id: 'eu', name: 'EU/EEA & UK' },
+    { id: 'mena', name: 'MENA' },
+    { id: 'latam', name: 'LATAM & Africa' },
+    { id: 'apac', name: 'APAC' },
+  ];
+
   return (
     <div className='min-h-screen bg-gradient-to-b from-background to-secondary/20'>
       <div className='container mx-auto py-12 px-4'>
-        <div className='max-w-4xl mx-auto'>
-          <h1 className='text-4xl font-bold mb-6'>
+        <div className='max-w-6xl mx-auto'>
+          <h1 className='text-4xl font-bold mb-2'>
             Financial Crime & Sanctions
           </h1>
+          <p className='text-sm text-muted-foreground mb-6'>
+            Last updated: December 2024
+          </p>
           <p className='text-lg text-muted-foreground mb-8'>
             Anti-money laundering, sanctions compliance, and financial crime
             prevention policies.
           </p>
-          <Link
-            to='/legal'
-            className='text-primary underline hover:no-underline'
-          >
-            View All Legal Documents
-          </Link>
+
+          {/* Region Navigation Strip */}
+          <div className='flex flex-wrap gap-2 mb-8 p-4 bg-secondary/50 rounded-lg'>
+            {regions.map(region => (
+              <a
+                key={region.id}
+                href={`#${region.id}`}
+                className='px-4 py-2 bg-background rounded hover:bg-primary/10 transition-colors text-sm font-medium'
+              >
+                {region.name}
+              </a>
+            ))}
+          </div>
+
+          {/* Region Sections */}
+          <div className='space-y-8 mb-12'>
+            <Card id='us'>
+              <CardHeader>
+                <CardTitle className='flex items-center gap-2'>
+                  <Globe className='h-5 w-5' />
+                  United States
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className='space-y-2'>
+                  <li>
+                    •{' '}
+                    <Link
+                      to='/legal/aml-bsa-program'
+                      className='text-primary hover:underline'
+                    >
+                      AML/BSA Program
+                    </Link>{' '}
+                    - Comprehensive anti-money laundering and Bank Secrecy Act
+                    compliance
+                  </li>
+                  <li>
+                    •{' '}
+                    <Link
+                      to='/legal/ofac-policy'
+                      className='text-primary hover:underline'
+                    >
+                      OFAC Sanctions Policy
+                    </Link>{' '}
+                    - Office of Foreign Assets Control sanctions screening and
+                    compliance
+                  </li>
+                  <li>
+                    •{' '}
+                    <Link
+                      to='/legal/esign-consent'
+                      className='text-primary hover:underline'
+                    >
+                      E-SIGN Consent
+                    </Link>{' '}
+                    - Electronic signature and document delivery authorization
+                  </li>
+                  <li>
+                    •{' '}
+                    <Link
+                      to='/legal/risk-disclosures'
+                      className='text-primary hover:underline'
+                    >
+                      Risk Disclosures
+                    </Link>{' '}
+                    - Investment and trading risk notifications
+                  </li>
+                </ul>
+              </CardContent>
+            </Card>
+
+            <Card id='eu'>
+              <CardHeader>
+                <CardTitle className='flex items-center gap-2'>
+                  <Globe className='h-5 w-5' />
+                  EU/EEA & UK
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className='space-y-2'>
+                  <li>
+                    •{' '}
+                    <Link
+                      to='/legal/privacy-policy'
+                      className='text-primary hover:underline'
+                    >
+                      Privacy Policy
+                    </Link>{' '}
+                    - GDPR compliance and data protection rights
+                  </li>
+                  <li>
+                    •{' '}
+                    <Link
+                      to='/legal/record-retention'
+                      className='text-primary hover:underline'
+                    >
+                      Record Retention
+                    </Link>{' '}
+                    - Document retention schedules per EU regulations
+                  </li>
+                  <li className='text-sm text-muted-foreground'>
+                    Note: Standard Contractual Clauses (SCCs) and adequacy
+                    decisions are detailed in the Privacy Policy
+                  </li>
+                </ul>
+              </CardContent>
+            </Card>
+
+            <Card id='mena'>
+              <CardHeader>
+                <CardTitle className='flex items-center gap-2'>
+                  <Globe className='h-5 w-5' />
+                  MENA
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className='space-y-2'>
+                  <li>
+                    •{' '}
+                    <Link
+                      to='/legal/aml-bsa-program'
+                      className='text-primary hover:underline'
+                    >
+                      AML/BSA Program
+                    </Link>{' '}
+                    - Regional AML compliance requirements
+                  </li>
+                  <li>
+                    •{' '}
+                    <Link
+                      to='/legal/risk-disclosures'
+                      className='text-primary hover:underline'
+                    >
+                      Risk Disclosures
+                    </Link>{' '}
+                    - Including commodity and FX risk considerations
+                  </li>
+                  <li className='text-sm text-muted-foreground'>
+                    Note: Sharia-compliant product considerations addressed in
+                    specific product terms
+                  </li>
+                </ul>
+              </CardContent>
+            </Card>
+
+            <Card id='latam'>
+              <CardHeader>
+                <CardTitle className='flex items-center gap-2'>
+                  <Globe className='h-5 w-5' />
+                  LATAM & Africa
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className='space-y-2'>
+                  <li>
+                    •{' '}
+                    <Link
+                      to='/legal/risk-disclosures'
+                      className='text-primary hover:underline'
+                    >
+                      Risk Disclosures
+                    </Link>{' '}
+                    - Emerging market and currency risk notifications
+                  </li>
+                  <li>
+                    •{' '}
+                    <Link
+                      to='/legal/refunds-shipping'
+                      className='text-primary hover:underline'
+                    >
+                      Refunds & Shipping
+                    </Link>{' '}
+                    - Physical asset fulfillment and logistics constraints
+                  </li>
+                  <li className='text-sm text-muted-foreground'>
+                    Note: Regional fulfillment constraints may apply for
+                    physical precious metals delivery
+                  </li>
+                </ul>
+              </CardContent>
+            </Card>
+
+            <Card id='apac'>
+              <CardHeader>
+                <CardTitle className='flex items-center gap-2'>
+                  <Globe className='h-5 w-5' />
+                  APAC
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className='space-y-2'>
+                  <li>
+                    •{' '}
+                    <Link
+                      to='/legal/privacy-policy'
+                      className='text-primary hover:underline'
+                    >
+                      Privacy Policy
+                    </Link>{' '}
+                    - APAC data protection and privacy requirements
+                  </li>
+                  <li>
+                    •{' '}
+                    <Link
+                      to='/legal/risk-disclosures'
+                      className='text-primary hover:underline'
+                    >
+                      Risk Disclosures
+                    </Link>{' '}
+                    - Regional market and regulatory risks
+                  </li>
+                </ul>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Canonical Policies Strip */}
+          <Card>
+            <CardHeader>
+              <CardTitle className='flex items-center gap-2'>
+                <FileText className='h-5 w-5' />
+                Canonical Policies
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className='flex flex-wrap gap-4'>
+                <Link
+                  to='/legal/aml-bsa-program'
+                  className='text-primary hover:underline'
+                >
+                  AML/BSA Program
+                </Link>
+                <span className='text-muted-foreground'>•</span>
+                <Link
+                  to='/legal/ofac-policy'
+                  className='text-primary hover:underline'
+                >
+                  OFAC Policy
+                </Link>
+                <span className='text-muted-foreground'>•</span>
+                <Link
+                  to='/legal/dealers-aml-memo'
+                  className='text-primary hover:underline'
+                >
+                  Dealers AML Memo
+                </Link>
+                <span className='text-muted-foreground'>•</span>
+                <Link
+                  to='/legal'
+                  className='font-semibold text-primary hover:underline'
+                >
+                  See all policies →
+                </Link>
+              </div>
+            </CardContent>
+          </Card>
         </div>
       </div>
     </div>

--- a/src/pages/legal/operations/index.tsx
+++ b/src/pages/legal/operations/index.tsx
@@ -1,21 +1,78 @@
 import { Link } from 'react-router-dom';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Package, Archive } from 'lucide-react';
 
 export default function OperationsHub() {
+  const operationsDocs = [
+    {
+      title: 'Refunds, Returns & Shipping',
+      description:
+        'Policies for refunds, returns, and physical asset shipping and fulfillment',
+      href: '/legal/refunds-shipping',
+      icon: Package,
+    },
+    {
+      title: 'Record Retention Schedule',
+      description: 'Document retention policies and data management procedures',
+      href: '/legal/record-retention',
+      icon: Archive,
+    },
+  ];
+
   return (
     <div className='min-h-screen bg-gradient-to-b from-background to-secondary/20'>
       <div className='container mx-auto py-12 px-4'>
-        <div className='max-w-4xl mx-auto'>
-          <h1 className='text-4xl font-bold mb-6'>Operations & Records</h1>
+        <div className='max-w-6xl mx-auto'>
+          <h1 className='text-4xl font-bold mb-4'>Operations & Records</h1>
           <p className='text-lg text-muted-foreground mb-8'>
-            Operational procedures, record keeping, and business continuity
-            policies.
+            Policies governing fulfillment operations, record management, and
+            business continuity procedures.
           </p>
-          <Link
-            to='/legal'
-            className='text-primary underline hover:no-underline'
-          >
-            View All Legal Documents
-          </Link>
+
+          <div className='grid grid-cols-1 md:grid-cols-2 gap-6 mb-8'>
+            {operationsDocs.map(doc => {
+              const Icon = doc.icon;
+              return (
+                <Card
+                  key={doc.href}
+                  className='hover:shadow-lg transition-shadow'
+                >
+                  <CardHeader>
+                    <div className='flex items-center space-x-2 mb-2'>
+                      <Icon className='h-5 w-5 text-primary' />
+                      <Link to={doc.href} className='hover:underline'>
+                        <CardTitle className='text-xl'>{doc.title}</CardTitle>
+                      </Link>
+                    </div>
+                    <CardDescription>{doc.description}</CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <Link
+                      to={doc.href}
+                      className='text-primary hover:underline text-sm'
+                    >
+                      View document →
+                    </Link>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+
+          <div className='mt-8'>
+            <Link
+              to='/legal'
+              className='text-primary underline hover:no-underline'
+            >
+              View All Legal Documents
+            </Link>
+          </div>
         </div>
       </div>
     </div>

--- a/src/pages/legal/operations/index.tsx
+++ b/src/pages/legal/operations/index.tsx
@@ -1,0 +1,23 @@
+import { Link } from 'react-router-dom';
+
+export default function OperationsHub() {
+  return (
+    <div className='min-h-screen bg-gradient-to-b from-background to-secondary/20'>
+      <div className='container mx-auto py-12 px-4'>
+        <div className='max-w-4xl mx-auto'>
+          <h1 className='text-4xl font-bold mb-6'>Operations & Records</h1>
+          <p className='text-lg text-muted-foreground mb-8'>
+            Operational procedures, record keeping, and business continuity
+            policies.
+          </p>
+          <Link
+            to='/legal'
+            className='text-primary underline hover:no-underline'
+          >
+            View All Legal Documents
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/legal/privacy/index.tsx
+++ b/src/pages/legal/privacy/index.tsx
@@ -1,20 +1,84 @@
 import { Link } from 'react-router-dom';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Shield, Eye, Accessibility } from 'lucide-react';
 
 export default function PrivacyHub() {
+  const privacyDocs = [
+    {
+      title: 'Privacy Policy',
+      description: 'How we collect, use, and protect your personal information',
+      href: '/legal/privacy-policy',
+      icon: Shield,
+    },
+    {
+      title: 'Privacy Choices',
+      description:
+        'Your rights regarding Do Not Sell/Share and data control options',
+      href: '/legal/privacy-choices',
+      icon: Eye,
+    },
+    {
+      title: 'Accessibility',
+      description: 'Our commitment to making PBCEx accessible to everyone',
+      href: '/legal/accessibility',
+      icon: Accessibility,
+    },
+  ];
+
   return (
     <div className='min-h-screen bg-gradient-to-b from-background to-secondary/20'>
       <div className='container mx-auto py-12 px-4'>
-        <div className='max-w-4xl mx-auto'>
-          <h1 className='text-4xl font-bold mb-6'>Privacy & Rights</h1>
+        <div className='max-w-6xl mx-auto'>
+          <h1 className='text-4xl font-bold mb-4'>Privacy & Rights</h1>
           <p className='text-lg text-muted-foreground mb-8'>
-            Your privacy rights and data protection policies.
+            Understand how we protect your privacy, respect your data rights,
+            and ensure accessible services for all users.
           </p>
-          <Link
-            to='/legal'
-            className='text-primary underline hover:no-underline'
-          >
-            View All Legal Documents
-          </Link>
+
+          <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8'>
+            {privacyDocs.map(doc => {
+              const Icon = doc.icon;
+              return (
+                <Card
+                  key={doc.href}
+                  className='hover:shadow-lg transition-shadow'
+                >
+                  <CardHeader>
+                    <div className='flex items-center space-x-2 mb-2'>
+                      <Icon className='h-5 w-5 text-primary' />
+                      <Link to={doc.href} className='hover:underline'>
+                        <CardTitle className='text-xl'>{doc.title}</CardTitle>
+                      </Link>
+                    </div>
+                    <CardDescription>{doc.description}</CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <Link
+                      to={doc.href}
+                      className='text-primary hover:underline text-sm'
+                    >
+                      View document →
+                    </Link>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+
+          <div className='mt-8'>
+            <Link
+              to='/legal'
+              className='text-primary underline hover:no-underline'
+            >
+              View All Legal Documents
+            </Link>
+          </div>
         </div>
       </div>
     </div>

--- a/src/pages/legal/privacy/index.tsx
+++ b/src/pages/legal/privacy/index.tsx
@@ -1,0 +1,22 @@
+import { Link } from 'react-router-dom';
+
+export default function PrivacyHub() {
+  return (
+    <div className='min-h-screen bg-gradient-to-b from-background to-secondary/20'>
+      <div className='container mx-auto py-12 px-4'>
+        <div className='max-w-4xl mx-auto'>
+          <h1 className='text-4xl font-bold mb-6'>Privacy & Rights</h1>
+          <p className='text-lg text-muted-foreground mb-8'>
+            Your privacy rights and data protection policies.
+          </p>
+          <Link
+            to='/legal'
+            className='text-primary underline hover:no-underline'
+          >
+            View All Legal Documents
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/legal/terms-risk/index.tsx
+++ b/src/pages/legal/terms-risk/index.tsx
@@ -1,20 +1,86 @@
 import { Link } from 'react-router-dom';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { FileText, PenTool, AlertTriangle } from 'lucide-react';
 
 export default function TermsRiskHub() {
+  const termsDocs = [
+    {
+      title: 'Terms of Service',
+      description:
+        'The legal agreement governing your use of PBCEx services and platform',
+      href: '/legal/terms-of-service',
+      icon: FileText,
+    },
+    {
+      title: 'E-SIGN Consent',
+      description:
+        'Authorization for electronic signatures and digital document delivery',
+      href: '/legal/esign-consent',
+      icon: PenTool,
+    },
+    {
+      title: 'Risk Disclosures',
+      description:
+        'Important information about investment, trading, and market risks',
+      href: '/legal/risk-disclosures',
+      icon: AlertTriangle,
+    },
+  ];
+
   return (
     <div className='min-h-screen bg-gradient-to-b from-background to-secondary/20'>
       <div className='container mx-auto py-12 px-4'>
-        <div className='max-w-4xl mx-auto'>
-          <h1 className='text-4xl font-bold mb-6'>Terms, Consent & Risk</h1>
+        <div className='max-w-6xl mx-auto'>
+          <h1 className='text-4xl font-bold mb-4'>Terms, Consent & Risk</h1>
           <p className='text-lg text-muted-foreground mb-8'>
-            Terms of service, user agreements, and risk disclosures.
+            Essential agreements and disclosures that govern your use of PBCEx
+            services and inform you of associated risks.
           </p>
-          <Link
-            to='/legal'
-            className='text-primary underline hover:no-underline'
-          >
-            View All Legal Documents
-          </Link>
+
+          <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8'>
+            {termsDocs.map(doc => {
+              const Icon = doc.icon;
+              return (
+                <Card
+                  key={doc.href}
+                  className='hover:shadow-lg transition-shadow'
+                >
+                  <CardHeader>
+                    <div className='flex items-center space-x-2 mb-2'>
+                      <Icon className='h-5 w-5 text-primary' />
+                      <Link to={doc.href} className='hover:underline'>
+                        <CardTitle className='text-xl'>{doc.title}</CardTitle>
+                      </Link>
+                    </div>
+                    <CardDescription>{doc.description}</CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <Link
+                      to={doc.href}
+                      className='text-primary hover:underline text-sm'
+                    >
+                      View document →
+                    </Link>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+
+          <div className='mt-8'>
+            <Link
+              to='/legal'
+              className='text-primary underline hover:no-underline'
+            >
+              View All Legal Documents
+            </Link>
+          </div>
         </div>
       </div>
     </div>

--- a/src/pages/legal/terms-risk/index.tsx
+++ b/src/pages/legal/terms-risk/index.tsx
@@ -1,0 +1,22 @@
+import { Link } from 'react-router-dom';
+
+export default function TermsRiskHub() {
+  return (
+    <div className='min-h-screen bg-gradient-to-b from-background to-secondary/20'>
+      <div className='container mx-auto py-12 px-4'>
+        <div className='max-w-4xl mx-auto'>
+          <h1 className='text-4xl font-bold mb-6'>Terms, Consent & Risk</h1>
+          <p className='text-lg text-muted-foreground mb-8'>
+            Terms of service, user agreements, and risk disclosures.
+          </p>
+          <Link
+            to='/legal'
+            className='text-primary underline hover:no-underline'
+          >
+            View All Legal Documents
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Summary: Implements four legal hub pages (Privacy, Compliance, Terms/Risk, Operations) with responsive tiles linking to all 11 canonical legal documents. Updates footer navigation to hub structure.

Changes: 4 hub pages populated; regional sections on Compliance; footer links updated; routes ensured; all 11 documents accessible at /legal/:slug.

Testing: TypeScript, ESLint, and build clean; verified 15 routes; responsive 3/2/1 grid; footer and Support→Compliance navigation correct.

Stats: 7 files changed, 557 insertions(+), 6 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added dedicated Legal hubs: Privacy & Rights, Financial Crime & Sanctions, Terms, Consent & Risk, and Operations & Records.
  - Introduced new /legal routes for each hub, featuring region/document cards, internal links, and “View all” navigation.
  - Updated Footer navigation: Support link now points to /legal/compliance and Legal links now target the new /legal pages.

- Style
  - Added a Settings icon to the Hedging Bots action button for improved UI clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->