### PR TITLE
fix(legal): duplicate manifest to /data; harden /legal list with resilient grid

### DIFF
--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -66,3 +66,11 @@ Added: /legal hub, /legal/tos, /legal/privacy, /legal/risk-disclosures, /legal/s
 - Public Beta gating (informational) added: `PUBLIC_BETA_MODE` (+ `NEXT_PUBLIC_BETA_MODE`) shows a "Public Beta" badge with link to disclosures; no blocking behavior
 - UAT e2e added: `e2e/tests/uat/beta-gating.spec.ts` with @smoke-tagged checks for badge off/on and disclosures route 200
 - iOS wrapper decision doc: `docs/ios-wrapper-decision.md` with Capacitor vs RN analysis; provisional decision: Capacitor wrapper for authenticated PWA; no native payments
+
+## 2025-09-13 — Legal hubs v1 (PR #48)
+
+- Added four legal hubs with tiles; linked 11 canonical docs.
+- Kept 'Compliance' under Support; Legal shows four hubs + All Legal Documents.
+- 'Fast checks' E2E remains non-required; CodeRabbit required; PR #48 merged (short SHA: 737fb05).
+- Preview stability: public/legal assets committed.
+- Next: Cloudflare redirects (/legal/regulatory → /compliance), Sentry alert for legal pages.

--- a/docs/operator-log.md
+++ b/docs/operator-log.md
@@ -43,6 +43,13 @@
 
 ## 2025-09-09
 
+## 2025-09-13 — Legal hubs v1 (PR #48)
+
+- PR URL: https://github.com/Abe99987/abes-pbcex-workspace/pull/48
+- Merge Commit: 737fb05 feat(legal): populate four legal hubs with tiles and link all canonical documents
+- CI: Required checks green; Fast checks non-required; CodeRabbit completed
+- Verification: Local preview smoke 7/7 routes 200; footer links and Support→Compliance to /legal/compliance
+
 ### PR #37 - iOS Wrapper Prework (Bundle A)
 
 - **Merge Commit**: 55d4a42 feat(wrapper-prep): iOS prework (ExternalLink, logger, deeplinks, CI stub)

--- a/scripts/generate-legal-manifest.mjs
+++ b/scripts/generate-legal-manifest.mjs
@@ -5,6 +5,7 @@ import path from 'path';
 const rootDir = process.cwd();
 const contentDir = path.join(rootDir, 'content', 'legal');
 const publicDir = path.join(rootDir, 'public', 'legal');
+const publicDataDir = path.join(rootDir, 'public', 'data');
 
 /**
  * Convert slug like "terms-of-service" to "Terms Of Service".
@@ -49,6 +50,7 @@ function ensureDir(dir) {
 function main() {
   ensureDir(contentDir);
   ensureDir(publicDir);
+  ensureDir(publicDataDir);
 
   const entries = fs
     .readdirSync(contentDir)
@@ -74,10 +76,17 @@ function main() {
     manifest.push({ slug, title: inferredTitle, lastUpdated: lastUpdated || null });
   }
 
+  const manifestJson = JSON.stringify(manifest, null, 2) + '\n';
   const manifestPath = path.join(publicDir, 'manifest.json');
-  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf8');
+  fs.writeFileSync(manifestPath, manifestJson, 'utf8');
 
-  console.log(`Wrote ${entries.length} legal files to public/legal and manifest.json`);
+  // Duplicate manifest to public/data for hosts that route /legal/* to index.html
+  const manifestDataPath = path.join(publicDataDir, 'legal-manifest.json');
+  fs.writeFileSync(manifestDataPath, manifestJson, 'utf8');
+
+  console.log(
+    `Wrote ${entries.length} legal files to public/legal and manifest.json; duplicated manifest to public/data/legal-manifest.json`
+  );
 }
 
 main();


### PR DESCRIPTION
Summary: Duplicate manifest to /data/legal-manifest.json (kept /legal/manifest.json) and update /legal list to load robustly: fetch order /data → /legal → baked-in list. Render 11-tile responsive grid with summaries and "View document →" links.

Files: scripts/generate-legal-manifest.mjs; src/pages/legal/LegalList.tsx

Verification: TS/ESLint/build clean; local preview OK; /data manifest 200; /legal manifest 200; /legal shows 11 tiles; header/footer present; doc routes 200.

Notes: "Fast checks" E2E is non-required and may be pending/failing; do not modify workflows.