### PR TITLE
feat(nav): header/menu overhaul + Markets→Analytics stub (dark)

### DIFF
--- a/frontend/components/Navigation.tsx
+++ b/frontend/components/Navigation.tsx
@@ -1,4 +1,4 @@
-import { useState, Fragment } from 'react';
+import { useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useAuth, getUserDisplayName } from '@/hooks/useAuth';
@@ -13,6 +13,17 @@ import {
   DollarSign,
   LogOut,
   LineChart,
+  CreditCard,
+  ArrowLeftRight,
+  Download,
+  Upload,
+  Landmark,
+  QrCode,
+  Calendar,
+  Repeat,
+  ShoppingCart,
+  Shield,
+  Settings,
 } from 'lucide-react';
 import { TickerTape } from '@/components/tradingview';
 
@@ -23,18 +34,195 @@ interface NavItem {
   description?: string;
 }
 
-const walletItems: NavItem[] = [
+// Buy Crypto dropdown
+const buyCryptoItems: NavItem[] = [
   {
-    name: 'My Assets',
-    href: '/wallet/assets',
-    icon: Wallet,
-    description: 'View and manage your portfolio',
+    name: 'Quick Buy (Placeholder)',
+    href: '/markets/BINANCE:BTCUSDT',
+    icon: CreditCard,
+    description: 'Fiat → asset in one step',
   },
   {
-    name: 'My Spending',
+    name: 'Quick Convert (Placeholder)',
+    href: '/wallet/assets',
+    icon: ArrowLeftRight,
+    description: 'Swap between assets instantly',
+  },
+  {
+    name: 'Buy with Card (Placeholder)',
     href: '/wallet/spending',
+    icon: CreditCard,
+    description: 'Visa/Mastercard checkout',
+  },
+  {
+    name: 'Deposit Crypto (Placeholder)',
+    href: '/wallet/assets',
+    icon: Download,
+    description: 'On-chain deposit addresses',
+  },
+];
+
+// Trade dropdown
+const tradeItems: NavItem[] = [
+  {
+    name: 'Spot (USD) (Placeholder)',
+    href: '/markets',
+    icon: LineChart,
+    description: 'USD-quoted markets',
+  },
+  {
+    name: 'Spot (USDC) (Placeholder)',
+    href: '/markets',
+    icon: LineChart,
+    description: 'USDC-quoted markets',
+  },
+  {
+    name: 'Coin-to-Coin (Placeholder)',
+    href: '/markets/BINANCE:BTCUSDT',
+    icon: ArrowLeftRight,
+    description: 'BTC/ETH quote pairs',
+  },
+  {
+    name: 'DCA (Placeholder)',
+    href: '/wallet/assets',
+    icon: Repeat,
+    description: 'Automated recurring purchases',
+  },
+];
+
+// Markets dropdown
+const marketsItems: NavItem[] = [
+  {
+    name: 'Analytics',
+    href: '/markets/analytics',
+    icon: BarChart3,
+    description: 'Overview & key metrics dashboard',
+  },
+  {
+    name: 'Tutorials (Placeholder)',
+    href: '/disclosures',
+    icon: FileText,
+    description: 'How-to guides',
+  },
+  {
+    name: 'Education (Learn) (Placeholder)',
+    href: '/legal',
+    icon: FileText,
+    description: 'Courses & long-form',
+  },
+];
+
+// Shop dropdown (link metals to symbols)
+const shopItems: NavItem[] = [
+  {
+    name: 'Shop All (Placeholder)',
+    href: '/markets',
+    icon: ShoppingCart,
+    description: 'View all commodities',
+  },
+  {
+    name: 'Buy Physical Gold',
+    href: '/markets/OANDA:XAUUSD',
     icon: DollarSign,
-    description: 'Track spending and budgets',
+    description: 'Gold',
+  },
+  {
+    name: 'Buy Physical Silver',
+    href: '/markets/OANDA:XAGUSD',
+    icon: DollarSign,
+    description: 'Silver',
+  },
+  {
+    name: 'Buy Physical Platinum',
+    href: '/markets/OANDA:XPTUSD',
+    icon: DollarSign,
+    description: 'Platinum',
+  },
+  {
+    name: 'Buy Physical Palladium',
+    href: '/markets/OANDA:XPDUSD',
+    icon: DollarSign,
+    description: 'Palladium',
+  },
+  {
+    name: 'Buy Physical Copper',
+    href: '/markets/COMEX:HG1!',
+    icon: DollarSign,
+    description: 'Copper',
+  },
+];
+
+// Send / Receive dropdown
+const transferItems: NavItem[] = [
+  {
+    name: 'Send to PBCEx User (Placeholder)',
+    href: '/wallet/assets',
+    icon: Upload,
+    description: 'Free & instant transfers',
+  },
+  {
+    name: 'Crypto Withdrawal (Placeholder)',
+    href: '/wallet/transactions',
+    icon: ArrowLeftRight,
+    description: 'Send on-chain',
+  },
+  {
+    name: 'Bank Transfers (SWIFT/WISE-ready) (Placeholder)',
+    href: '/wallet/transactions',
+    icon: Landmark,
+    description: 'Domestic & international',
+  },
+  {
+    name: 'Pay with QR Code (Placeholder)',
+    href: '/wallet/spending',
+    icon: QrCode,
+    description: 'Merchant QR',
+  },
+  {
+    name: 'Receive with QR Code (Placeholder)',
+    href: '/wallet/spending',
+    icon: QrCode,
+    description: 'Your QR',
+  },
+  {
+    name: 'Spend with Visa Card (Placeholder)',
+    href: '/wallet/spending',
+    icon: CreditCard,
+    description: 'Use card',
+  },
+  {
+    name: 'Set up Bill Pay (Placeholder)',
+    href: '/wallet/spending',
+    icon: Calendar,
+    description: 'Schedule utilities & vendors',
+  },
+  {
+    name: 'Request a Payment (Placeholder)',
+    href: '/wallet/transactions',
+    icon: FileText,
+    description: 'Create invoice/QR',
+  },
+  {
+    name: 'Set up Recurring Transfers (Placeholder)',
+    href: '/wallet/transactions',
+    icon: Repeat,
+    description: 'Automate payouts & savings',
+  },
+];
+
+// My Account (Wallet) dropdown
+const walletItems: NavItem[] = [
+  {
+    name: 'Balances & Funding',
+    href: '/wallet/assets',
+    icon: Wallet,
+    description: 'Balances, deposit, and funding options',
+  },
+  {
+    name: 'Cards (Placeholder)',
+    href: '/wallet/spending',
+    icon: CreditCard,
+    description: 'Manage cards and spending',
   },
   {
     name: 'Transaction History',
@@ -54,11 +242,40 @@ const walletItems: NavItem[] = [
     icon: TrendingUp,
     description: 'Profit & loss analytics',
   },
+  {
+    name: 'Connect Wallet (Placeholder)',
+    href: '/wallet/assets',
+    icon: ArrowLeftRight,
+    description: 'Connect external wallet',
+  },
+  {
+    name: 'Security (Placeholder)',
+    href: '/legal/privacy',
+    icon: Shield,
+    description: '2FA and security settings',
+  },
+  {
+    name: 'Settings & Profile (Placeholder)',
+    href: '/dashboard',
+    icon: Settings,
+    description: 'Manage your profile and preferences',
+  },
+  {
+    name: 'Support (Placeholder)',
+    href: '/disclosures',
+    icon: FileText,
+    description: 'Help center and support',
+  },
 ];
 
 export default function Navigation() {
   const { user, logout } = useAuth();
   const router = useRouter();
+  const [buyDropdownOpen, setBuyDropdownOpen] = useState(false);
+  const [tradeDropdownOpen, setTradeDropdownOpen] = useState(false);
+  const [marketsDropdownOpen, setMarketsDropdownOpen] = useState(false);
+  const [shopDropdownOpen, setShopDropdownOpen] = useState(false);
+  const [transferDropdownOpen, setTransferDropdownOpen] = useState(false);
   const [walletDropdownOpen, setWalletDropdownOpen] = useState(false);
   const [userDropdownOpen, setUserDropdownOpen] = useState(false);
 
@@ -86,63 +303,209 @@ export default function Navigation() {
               </Link>
             </div>
             <div className='hidden sm:-my-px sm:ml-6 sm:flex sm:space-x-8'>
-              <Link
-                href='/dashboard'
-                className={`inline-flex items-center px-1 pt-1 text-sm font-medium ${
-                  router.pathname === '/dashboard'
-                    ? 'border-b-2 border-blue-500 text-gray-900'
-                    : 'text-gray-500 hover:text-gray-700'
-                }`}
-              >
-                Dashboard
-              </Link>
+              {/* Buy Crypto */}
+              <div className='relative'>
+                <button
+                  onClick={() => setBuyDropdownOpen(!buyDropdownOpen)}
+                  aria-expanded={buyDropdownOpen}
+                  className={`inline-flex items-center px-1 pt-1 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${
+                    buyDropdownOpen ? 'text-gray-900' : 'text-gray-500 hover:text-gray-700'
+                  }`}
+                >
+                  Buy Crypto
+                  <ChevronDown className='ml-1 h-4 w-4' />
+                </button>
+                {buyDropdownOpen && (
+                  <div className='absolute left-0 top-full z-10 mt-2 w-96 origin-top-left rounded-md bg-white py-2 shadow-lg ring-1 ring-black ring-opacity-5'>
+                    {buyCryptoItems.map(item => (
+                      <Link
+                        key={item.name}
+                        href={item.href}
+                        onClick={() => setBuyDropdownOpen(false)}
+                        className='block px-4 py-3 text-sm hover:bg-gray-50 focus:bg-gray-50 focus:outline-none'
+                      >
+                        <div className='flex items-start space-x-3'>
+                          <item.icon className='h-5 w-5 text-gray-400 mt-0.5' />
+                          <div>
+                            <div className='font-medium text-gray-900'>{item.name}</div>
+                            {item.description && (
+                              <div className='text-gray-500 text-xs'>{item.description}</div>
+                            )}
+                          </div>
+                        </div>
+                      </Link>
+                    ))}
+                  </div>
+                )}
+              </div>
 
-              {/* Markets Link */}
-              <Link
-                href='/markets'
-                className={`inline-flex items-center px-1 pt-1 text-sm font-medium ${
-                  router.pathname.startsWith('/markets')
-                    ? 'border-b-2 border-blue-500 text-gray-900'
-                    : 'text-gray-500 hover:text-gray-700'
-                }`}
-              >
-                <LineChart className='mr-1 h-4 w-4' />
-                Markets
-              </Link>
+              {/* Trade */}
+              <div className='relative'>
+                <button
+                  onClick={() => setTradeDropdownOpen(!tradeDropdownOpen)}
+                  aria-expanded={tradeDropdownOpen}
+                  className={`inline-flex items-center px-1 pt-1 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${
+                    router.pathname.startsWith('/markets') ? 'text-gray-900' : 'text-gray-500 hover:text-gray-700'
+                  }`}
+                >
+                  Trade
+                  <ChevronDown className='ml-1 h-4 w-4' />
+                </button>
+                {tradeDropdownOpen && (
+                  <div className='absolute left-0 top-full z-10 mt-2 w-96 origin-top-left rounded-md bg-white py-2 shadow-lg ring-1 ring-black ring-opacity-5'>
+                    {tradeItems.map(item => (
+                      <Link
+                        key={item.name}
+                        href={item.href}
+                        onClick={() => setTradeDropdownOpen(false)}
+                        className='block px-4 py-3 text-sm hover:bg-gray-50 focus:bg-gray-50 focus:outline-none'
+                      >
+                        <div className='flex items-start space-x-3'>
+                          <item.icon className='h-5 w-5 text-gray-400 mt-0.5' />
+                          <div>
+                            <div className='font-medium text-gray-900'>{item.name}</div>
+                            {item.description && (
+                              <div className='text-gray-500 text-xs'>{item.description}</div>
+                            )}
+                          </div>
+                        </div>
+                      </Link>
+                    ))}
+                  </div>
+                )}
+              </div>
 
-              {/* Disclosures Link */}
-              <Link
-                href='/disclosures'
-                className={`inline-flex items-center px-1 pt-1 text-sm font-medium ${
-                  router.pathname === '/disclosures'
-                    ? 'border-b-2 border-blue-500 text-gray-900'
-                    : 'text-gray-500 hover:text-gray-700'
-                }`}
-              >
-                Disclosures
-              </Link>
+              {/* Markets */}
+              <div className='relative'>
+                <button
+                  onClick={() => setMarketsDropdownOpen(!marketsDropdownOpen)}
+                  aria-expanded={marketsDropdownOpen}
+                  className={`inline-flex items-center px-1 pt-1 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${
+                    router.pathname.startsWith('/markets') ? 'text-gray-900' : 'text-gray-500 hover:text-gray-700'
+                  }`}
+                >
+                  <LineChart className='mr-1 h-4 w-4' />
+                  Markets
+                  <ChevronDown className='ml-1 h-4 w-4' />
+                </button>
+                {marketsDropdownOpen && (
+                  <div className='absolute left-0 top-full z-10 mt-2 w-96 origin-top-left rounded-md bg-white py-2 shadow-lg ring-1 ring-black ring-opacity-5'>
+                    {marketsItems.map(item => (
+                      <Link
+                        key={item.name}
+                        href={item.href}
+                        onClick={() => setMarketsDropdownOpen(false)}
+                        className='block px-4 py-3 text-sm hover:bg-gray-50 focus:bg-gray-50 focus:outline-none'
+                      >
+                        <div className='flex items-start space-x-3'>
+                          <item.icon className='h-5 w-5 text-gray-400 mt-0.5' />
+                          <div>
+                            <div className='font-medium text-gray-900'>{item.name}</div>
+                            {item.description && (
+                              <div className='text-gray-500 text-xs'>{item.description}</div>
+                            )}
+                          </div>
+                        </div>
+                      </Link>
+                    ))}
+                  </div>
+                )}
+              </div>
 
-              {/* Wallet Dropdown */}
+              {/* Shop */}
+              <div className='relative'>
+                <button
+                  onClick={() => setShopDropdownOpen(!shopDropdownOpen)}
+                  aria-expanded={shopDropdownOpen}
+                  className={`inline-flex items-center px-1 pt-1 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${
+                    router.pathname.startsWith('/markets') ? 'text-gray-900' : 'text-gray-500 hover:text-gray-700'
+                  }`}
+                >
+                  Shop
+                  <ChevronDown className='ml-1 h-4 w-4' />
+                </button>
+                {shopDropdownOpen && (
+                  <div className='absolute left-0 top-full z-10 mt-2 w-96 origin-top-left rounded-md bg-white py-2 shadow-lg ring-1 ring-black ring-opacity-5'>
+                    {shopItems.map(item => (
+                      <Link
+                        key={item.name}
+                        href={item.href}
+                        onClick={() => setShopDropdownOpen(false)}
+                        className='block px-4 py-3 text-sm hover:bg-gray-50 focus:bg-gray-50 focus:outline-none'
+                      >
+                        <div className='flex items-start space-x-3'>
+                          <item.icon className='h-5 w-5 text-gray-400 mt-0.5' />
+                          <div>
+                            <div className='font-medium text-gray-900'>{item.name}</div>
+                            {item.description && (
+                              <div className='text-gray-500 text-xs'>{item.description}</div>
+                            )}
+                          </div>
+                        </div>
+                      </Link>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {/* Send / Receive */}
+              <div className='relative'>
+                <button
+                  onClick={() => setTransferDropdownOpen(!transferDropdownOpen)}
+                  aria-expanded={transferDropdownOpen}
+                  className={`inline-flex items-center px-1 pt-1 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${
+                    router.pathname.startsWith('/wallet') ? 'text-gray-900' : 'text-gray-500 hover:text-gray-700'
+                  }`}
+                >
+                  Send / Receive
+                  <ChevronDown className='ml-1 h-4 w-4' />
+                </button>
+                {transferDropdownOpen && (
+                  <div className='absolute left-0 top-full z-10 mt-2 w-[28rem] origin-top-left rounded-md bg-white py-2 shadow-lg ring-1 ring-black ring-opacity-5'>
+                    {transferItems.map(item => (
+                      <Link
+                        key={item.name}
+                        href={item.href}
+                        onClick={() => setTransferDropdownOpen(false)}
+                        className='block px-4 py-3 text-sm hover:bg-gray-50 focus:bg-gray-50 focus:outline-none'
+                      >
+                        <div className='flex items-start space-x-3'>
+                          <item.icon className='h-5 w-5 text-gray-400 mt-0.5' />
+                          <div>
+                            <div className='font-medium text-gray-900'>{item.name}</div>
+                            {item.description && (
+                              <div className='text-gray-500 text-xs'>{item.description}</div>
+                            )}
+                          </div>
+                        </div>
+                      </Link>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {/* My Account (Wallet) */}
               <div className='relative'>
                 <button
                   onClick={() => setWalletDropdownOpen(!walletDropdownOpen)}
-                  className={`inline-flex items-center px-1 pt-1 text-sm font-medium ${
+                  aria-expanded={walletDropdownOpen}
+                  className={`inline-flex items-center px-1 pt-1 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${
                     router.pathname.startsWith('/wallet')
-                      ? 'border-b-2 border-blue-500 text-gray-900'
+                      ? 'text-gray-900'
                       : 'text-gray-500 hover:text-gray-700'
                   }`}
                 >
-                  Wallet
+                  My Account
                   <ChevronDown className='ml-1 h-4 w-4' />
                 </button>
                 {walletDropdownOpen && (
-                  <div className='absolute left-0 top-full z-10 mt-2 w-80 origin-top-left rounded-md bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5'>
+                  <div className='absolute left-0 top-full z-10 mt-2 w-96 origin-top-left rounded-md bg-white py-2 shadow-lg ring-1 ring-black ring-opacity-5'>
                     {walletItems.map(item => (
                       <Link
                         key={item.name}
                         href={item.href}
                         onClick={() => setWalletDropdownOpen(false)}
-                        className='block px-4 py-3 text-sm hover:bg-gray-50'
+                        className='block px-4 py-3 text-sm hover:bg-gray-50 focus:bg-gray-50 focus:outline-none'
                       >
                         <div className='flex items-start space-x-3'>
                           <item.icon className='h-5 w-5 text-gray-400 mt-0.5' />

--- a/frontend/pages/markets/analytics.tsx
+++ b/frontend/pages/markets/analytics.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import Navigation from '@/components/Navigation';
+import { useAuth } from '@/hooks/useAuth';
+import { TrendingUp, BarChart3, Activity, LineChart } from 'lucide-react';
+
+export default function Analytics() {
+  const { user, isLoading: authLoading } = useAuth();
+
+  if (authLoading) {
+    return (
+      <div className='min-h-screen dark bg-slate-950'>
+        <Navigation />
+        <div className='flex items-center justify-center h-96'>
+          <div className='animate-spin rounded-full h-32 w-32 border-b-2 border-amber-500'></div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className='min-h-screen dark bg-slate-950'>
+        <Navigation />
+        <div className='flex items-center justify-center h-96'>
+          <div className='text-center'>
+            <h1 className='text-2xl font-bold text-slate-50 mb-4'>
+              Please log in to view Analytics
+            </h1>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const tileClass = 'bg-slate-900 border border-slate-800 rounded-xl p-4 flex flex-col gap-1';
+  const cardClass = 'bg-slate-900 border border-slate-800 rounded-xl p-4';
+  const tableClass = 'w-full text-sm text-slate-200';
+
+  return (
+    <div className='min-h-screen dark bg-slate-950'>
+      <Navigation />
+
+      <header className='border-b border-slate-800 bg-slate-950/50 backdrop-blur supports-[backdrop-filter]:bg-slate-950/50'>
+        <div className='max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6'>
+          <div className='flex items-center justify-between'>
+            <div>
+              <h1 className='text-3xl font-bold text-slate-50'>Analytics</h1>
+              <p className='text-slate-400 mt-1'>Overview & key market metrics</p>
+            </div>
+            <div className='flex items-center gap-2'>
+              <Link href='/markets' className='text-slate-300 hover:text-white text-sm'>Back to Markets</Link>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <main className='max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8'>
+        {/* Top row tiles */}
+        <section className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4'>
+          {/* Fear & Greed Index */}
+          <div className={tileClass}>
+            <div className='flex items-center justify-between'>
+              <div className='text-slate-400 text-xs uppercase tracking-wide'>Fear & Greed</div>
+              <Activity className='h-4 w-4 text-amber-400' />
+            </div>
+            <div className='relative mt-2 h-28 rounded-lg overflow-hidden border border-slate-800'>
+              <Image
+                src='https://alternative.me/crypto/fear-and-greed-index.png'
+                alt='Crypto Fear & Greed Index'
+                fill
+                sizes='(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 25vw'
+                className='object-contain bg-slate-950'
+              />
+            </div>
+            <div className='text-[10px] text-slate-500 mt-2'>Source: Alternative.me</div>
+          </div>
+
+          {/* Market Cap Δ (24h) */}
+          <div className={tileClass}>
+            <div className='flex items-center justify-between'>
+              <div className='text-slate-400 text-xs uppercase tracking-wide'>Market Cap Δ (24h)</div>
+              <BarChart3 className='h-4 w-4 text-emerald-400' />
+            </div>
+            <div className='mt-3 text-2xl font-semibold text-slate-50'>+2.3%</div>
+            <div className='text-slate-500 text-xs'>vs. previous 24h</div>
+          </div>
+
+          {/* Trading Vol Δ (24h) */}
+          <div className={tileClass}>
+            <div className='flex items-center justify-between'>
+              <div className='text-slate-400 text-xs uppercase tracking-wide'>Trading Vol Δ (24h)</div>
+              <TrendingUp className='h-4 w-4 text-sky-400' />
+            </div>
+            <div className='mt-3 text-2xl font-semibold text-slate-50'>-1.1%</div>
+            <div className='text-slate-500 text-xs'>vs. previous 24h</div>
+          </div>
+
+          {/* Gas Price */}
+          <div className={tileClass}>
+            <div className='flex items-center justify-between'>
+              <div className='text-slate-400 text-xs uppercase tracking-wide'>Gas Price</div>
+              <LineChart className='h-4 w-4 text-fuchsia-400' />
+            </div>
+            <div className='mt-3 text-2xl font-semibold text-slate-50'>26 gwei</div>
+            <div className='text-slate-500 text-xs'>Ethereum mainnet (placeholder)</div>
+          </div>
+        </section>
+
+        {/* Top Movers */}
+        <section className={cardClass}>
+          <div className='flex items-center justify-between mb-4'>
+            <h2 className='text-lg font-semibold text-slate-50'>Top Movers</h2>
+            <Link href='/markets' className='text-amber-400 hover:text-amber-300 text-sm'>View all</Link>
+          </div>
+          <div className='grid grid-cols-1 md:grid-cols-3 gap-4'>
+            {[{t:'BTC',p:'+3.2%'},{t:'ETH',p:'-1.1%'},{t:'XAU',p:'+0.6%'}].map(({t,p}) => (
+              <div key={t} className='border border-slate-800 rounded-lg p-3 flex items-center justify-between'>
+                <div className='text-slate-200 font-medium'>{t}</div>
+                <div className={`text-sm ${p.startsWith('-') ? 'text-red-400' : 'text-emerald-400'}`}>{p}</div>
+                <Link href={`/markets/${t==='XAU'?'OANDA:XAUUSD':t==='ETH'?'BINANCE:ETHUSDT':'BINANCE:BTCUSDT'}`} className='ml-3 px-3 py-1.5 text-xs rounded bg-amber-500 text-slate-900 hover:bg-amber-400'>Trade</Link>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Compact tables */}
+        <section className='grid grid-cols-1 md:grid-cols-3 gap-4'>
+          {[
+            { title: 'Most Traded', rows: [ ['BTC/USDT','—','Trade'], ['ETH/USDT','—','Trade'], ['XAU/USD','—','Trade'] ] },
+            { title: 'Trending', rows: [ ['SOL/USDT','—','Trade'], ['XAG/USD','—','Trade'], ['ADA/USDT','—','Trade'] ] },
+            { title: 'Newly Listed', rows: [ ['PAXG/USD','—','Trade'], ['COMEX:HG1!','—','Trade'], ['XPT/USD','—','Trade'] ] },
+          ].map(section => (
+            <div key={section.title} className={cardClass}>
+              <h3 className='text-base font-semibold text-slate-50 mb-3'>{section.title}</h3>
+              <table className={tableClass}>
+                <tbody>
+                  {section.rows.map(([pair, vol]) => (
+                    <tr key={pair} className='border-t border-slate-800'>
+                      <td className='py-2 text-slate-300'>{pair}</td>
+                      <td className='py-2 text-slate-500'>{vol}</td>
+                      <td className='py-2 text-right'>
+                        <Link href={`/markets/${pair.includes('XAU')?'OANDA:XAUUSD':pair.includes('XAG')?'OANDA:XAGUSD':pair.includes('ETH')?'BINANCE:ETHUSDT':pair.includes('BTC')?'BINANCE:BTCUSDT':pair.includes('SOL')?'SOLUSD':pair.includes('ADA')?'ADAUSD':pair.includes('XPT')?'OANDA:XPTUSD':pair.includes('HG1')?'COMEX:HG1!':'OANDA:XAUUSD'}`} className='px-3 py-1.5 text-xs rounded bg-amber-500 text-slate-900 hover:bg-amber-400'>Trade</Link>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ))}
+        </section>
+      </main>
+    </div>
+  );
+}
+
+

--- a/frontend/pages/markets/analytics.tsx
+++ b/frontend/pages/markets/analytics.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Image from 'next/image';
 import Link from 'next/link';
 import Navigation from '@/components/Navigation';
 import { useAuth } from '@/hooks/useAuth';
@@ -38,6 +37,20 @@ export default function Analytics() {
   const cardClass = 'bg-slate-900 border border-slate-800 rounded-xl p-4';
   const tableClass = 'w-full text-sm text-slate-200';
 
+  const getHrefForPair = (pair: string): string => {
+    const p = pair.toUpperCase();
+    if (p.includes('XAU')) return '/markets/OANDA:XAUUSD';
+    if (p.includes('XAG')) return '/markets/OANDA:XAGUSD';
+    if (p.includes('XPT')) return '/markets/OANDA:XPTUSD';
+    if (p.includes('HG1')) return '/markets/COMEX:HG1!';
+    if (p.includes('ETH')) return '/markets/BINANCE:ETHUSDT';
+    if (p.includes('BTC')) return '/markets/BINANCE:BTCUSDT';
+    if (p.includes('SOL')) return '/markets/SOLUSD';
+    if (p.includes('ADA')) return '/markets/ADAUSD';
+    if (p.includes('PAXG')) return '/markets/OANDA:XAUUSD';
+    return '/markets/OANDA:XAUUSD';
+  };
+
   return (
     <div className='min-h-screen dark bg-slate-950'>
       <Navigation />
@@ -65,14 +78,8 @@ export default function Analytics() {
               <div className='text-slate-400 text-xs uppercase tracking-wide'>Fear & Greed</div>
               <Activity className='h-4 w-4 text-amber-400' />
             </div>
-            <div className='relative mt-2 h-28 rounded-lg overflow-hidden border border-slate-800'>
-              <Image
-                src='https://alternative.me/crypto/fear-and-greed-index.png'
-                alt='Crypto Fear & Greed Index'
-                fill
-                sizes='(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 25vw'
-                className='object-contain bg-slate-950'
-              />
+            <div className='relative mt-2 h-28 rounded-lg overflow-hidden border border-slate-800 bg-slate-950'>
+              <img src='https://alternative.me/crypto/fear-and-greed-index.png' alt='Crypto Fear & Greed Index' className='w-full h-full object-contain' />
             </div>
             <div className='text-[10px] text-slate-500 mt-2'>Source: Alternative.me</div>
           </div>
@@ -127,21 +134,21 @@ export default function Analytics() {
 
         {/* Compact tables */}
         <section className='grid grid-cols-1 md:grid-cols-3 gap-4'>
-          {[
-            { title: 'Most Traded', rows: [ ['BTC/USDT','—','Trade'], ['ETH/USDT','—','Trade'], ['XAU/USD','—','Trade'] ] },
-            { title: 'Trending', rows: [ ['SOL/USDT','—','Trade'], ['XAG/USD','—','Trade'], ['ADA/USDT','—','Trade'] ] },
-            { title: 'Newly Listed', rows: [ ['PAXG/USD','—','Trade'], ['COMEX:HG1!','—','Trade'], ['XPT/USD','—','Trade'] ] },
-          ].map(section => (
+          {([
+            { title: 'Most Traded', rows: ['BTC/USDT', 'ETH/USDT', 'XAU/USD'] },
+            { title: 'Trending', rows: ['SOL/USDT', 'XAG/USD', 'ADA/USDT'] },
+            { title: 'Newly Listed', rows: ['PAXG/USD', 'COMEX:HG1!', 'XPT/USD'] },
+          ] as Array<{ title: string; rows: string[] }>).map(section => (
             <div key={section.title} className={cardClass}>
               <h3 className='text-base font-semibold text-slate-50 mb-3'>{section.title}</h3>
               <table className={tableClass}>
                 <tbody>
-                  {section.rows.map(([pair, vol]) => (
+                  {section.rows.map((pair) => (
                     <tr key={pair} className='border-t border-slate-800'>
                       <td className='py-2 text-slate-300'>{pair}</td>
-                      <td className='py-2 text-slate-500'>{vol}</td>
+                      <td className='py-2 text-slate-500'>—</td>
                       <td className='py-2 text-right'>
-                        <Link href={`/markets/${pair.includes('XAU')?'OANDA:XAUUSD':pair.includes('XAG')?'OANDA:XAGUSD':pair.includes('ETH')?'BINANCE:ETHUSDT':pair.includes('BTC')?'BINANCE:BTCUSDT':pair.includes('SOL')?'SOLUSD':pair.includes('ADA')?'ADAUSD':pair.includes('XPT')?'OANDA:XPTUSD':pair.includes('HG1')?'COMEX:HG1!':'OANDA:XAUUSD'}`} className='px-3 py-1.5 text-xs rounded bg-amber-500 text-slate-900 hover:bg-amber-400'>Trade</Link>
+                        <Link href={getHrefForPair(pair)} className='px-3 py-1.5 text-xs rounded bg-amber-500 text-slate-900 hover:bg-amber-400'>Trade</Link>
                       </td>
                     </tr>
                   ))}


### PR DESCRIPTION
Implements code-driven nav overhaul and adds /markets/analytics dark scaffold.\n\nMilestones\n- M1: Located header/menu (Navigation.tsx) and route entry points.\n- M2: Implemented new nav order + two-line dropdowns. Removed Franchise/Security from header.\n- M3: Added /markets/analytics dark page with Fear & Greed tile, top movers, compact tables.\n- M4: Ready for CodeRabbit review.\n\nNotes\n- Dropdown items have title + muted subtext; focus/keyboard visible.\n- Links wired to existing routes; missing targets point to nearest existing with (Placeholder).\n- No repo-wide config changes; no paid APIs.\n\nScreenshots (to attach in review):\n- Header with dropdowns (light)\n- Analytics page (dark)\n\nLocal checks\n- TypeScript: clean\n- ESLint: clean (1 warning acceptable: no-img-element for external F&G tile)