### PR TITLE
ci: skip heavy jobs on docs-only changes; workflows trigger only on code/config

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,37 @@
+name: Actionlint
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: '20.12.2'
+
+jobs:
+  actionlint:
+    name: Lint GitHub Workflows
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Verify handbook submodule
+        run: |
+          git submodule status --recursive
+          test -f docs/handbook-mount/docs/index.md
+      - uses: reviewdog/action-actionlint@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,23 @@ name: CI Pipeline
 
 on:
   pull_request:
+    paths:
+      - 'src/**'
+      - 'backend/**'
+      - 'frontend/**'
+      - 'e2e/**'
+      - 'scripts/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'package-lock.json'
+      - 'vite.config.ts'
+      - '.eslintrc.*'
+      - 'tsconfig*.json'
+      - '.github/workflows/**'
+      - '!docs/**'
+      - '!prompts/**'
+      - '!.gitmodules'
+      - '!**/*.md'
   push:
     branches: [main]
 
@@ -16,22 +33,6 @@ env:
   NODE_VERSION: '20.12.2'
 
 jobs:
-  actionlint:
-    name: Lint GitHub Workflows
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
-      - name: Verify handbook submodule
-        run: |
-          git submodule status --recursive
-          test -f docs/handbook-mount/docs/index.md
-      - uses: reviewdog/action-actionlint@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
   backend:
     name: Backend (lint + build + test)
     runs-on: ubuntu-latest
@@ -138,19 +139,17 @@ jobs:
 
   summary:
     name: CI Summary
-    needs: [actionlint, backend, frontend]
+    needs: [backend, frontend]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
       - name: Print job results
         run: |
-          echo "actionlint: ${{ needs.actionlint.result }}"
           echo "backend:    ${{ needs.backend.result }}"
           echo "frontend:   ${{ needs.frontend.result }}"
 
           # Check if any required job failed
-          if [[ "${{ needs.actionlint.result }}" != "success" || \
-                "${{ needs.backend.result }}" != "success" || \
+          if [[ "${{ needs.backend.result }}" != "success" || \
                 "${{ needs.frontend.result }}" != "success" ]]; then
             echo "❌ CI Pipeline failed - some jobs did not complete successfully"
             exit 1

--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -2,6 +2,22 @@ name: CI Checks and E2E
 
 on:
   pull_request:
+    paths:
+      - 'src/**'
+      - 'backend/**'
+      - 'frontend/**'
+      - 'e2e/**'
+      - 'scripts/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'package-lock.json'
+      - 'vite.config.ts'
+      - '.eslintrc.*'
+      - 'tsconfig*.json'
+      - '!docs/**'
+      - '!prompts/**'
+      - '!.gitmodules'
+      - '!**/*.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pr-smoke.yml
+++ b/.github/workflows/pr-smoke.yml
@@ -4,11 +4,21 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
+      - 'src/**'
+      - 'backend/**'
       - 'frontend/**'
       - 'e2e/**'
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
+      - 'scripts/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'package-lock.json'
+      - 'vite.config.ts'
+      - '.eslintrc.*'
+      - 'tsconfig*.json'
+      - '!docs/**'
+      - '!prompts/**'
+      - '!.gitmodules'
+      - '!**/*.md'
 
 concurrency:
   group: pr-smoke-${{ github.head_ref }}


### PR DESCRIPTION
Skip CI overhead for docs-only PRs by adding path filters to heavy workflows. Workflows now trigger only on code/config changes, not documentation updates.

**Edited workflows:**
- **ci.yml**: Added path filters, moved actionlint to separate workflow
- **playwright-e2e.yml**: Added path filters to skip docs-only changes  
- **pr-smoke.yml**: Updated path filters to match standard pattern
- **actionlint.yml**: New workflow that triggers only on .github/workflows/** changes

**Path filters trigger on:** src/**, backend/**, frontend/**, e2e/**, scripts/**, package files, configs
**Path filters skip:** docs/**, prompts/**, .gitmodules, *.md files

No app code changed - only .github/workflows/* modifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Introduced a dedicated workflow linter with automated review comments.
  - Streamlined CI by running only on relevant changes and removing redundant workflow-lint step from main CI.
  - Applied path-based triggers to E2E and PR smoke checks to reduce unnecessary runs.
  - Enabled automatic cancellation of in-progress runs when newer commits arrive.
  - Standardized environment settings (including Node 20) and tightened default permissions.
  - Simplified CI summary to reflect only backend/frontend results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->